### PR TITLE
Set Next.js output mode to 'export'.

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  output: 'export',
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
This enables the static export of the application, making it suitable for deployment without a Node.js server. Adjustments to image handling remain intact with unoptimized images.